### PR TITLE
Fix Find() for types with generic arguments

### DIFF
--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/DataTemplateObjectBase.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/DataTemplateObjectBase.cs
@@ -1,0 +1,14 @@
+﻿namespace CoparooInterfaceTest
+{
+    using Trumpf.Coparoo.Desktop.WPF;
+
+    public interface IDataTemplateObjectBase : IControlObject
+    {
+    }
+
+    public class DataTemplateObjectBase<T> : ViewControlObject<T>, IDataTemplateObjectBase where T : FrameworkElement
+    {
+        /// <inheritdoc />
+        protected override Search SearchPattern => new Search();
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/DialogControlObject.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/DialogControlObject.cs
@@ -1,0 +1,20 @@
+﻿
+namespace CoparooInterfaceTest
+{
+    using System.Windows;
+    using Trumpf.Coparoo.Desktop.WPF;
+
+    public interface IDialogControlObject : IControlObject
+    {
+    }
+
+    public class DialogControlObject<T> : ViewControlObject<FrameworkElement>, IDialogControlObject where T : ContentControl
+    {
+        public void TestMethod1()
+        {
+        }
+
+        /// <inheritdoc />
+        protected override Search SearchPattern => new Search();
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ElementMocks.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ElementMocks.cs
@@ -1,0 +1,17 @@
+﻿namespace CoparooInterfaceTest
+{
+    public class FrameworkElement
+    {
+        // noop
+    }
+
+    public class ListBox
+    {
+        // noop
+    }
+
+    public class ContentControl
+    {
+        // noop
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/GenericArgumentTests.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/GenericArgumentTests.cs
@@ -1,0 +1,25 @@
+﻿namespace CoparooInterfaceTest
+{
+    using NUnit.Framework;
+    using Trumpf.Coparoo.Desktop;
+
+    [TestFixture]
+    public class GenericArgumentTests
+    {
+        [Test]
+        public void WhenTryingToFindControlObjectWithGenericArgument_CorrectTypeIsReturned()
+        {
+            // during resolve it should not hit unrelated types like DialogControlObject
+            var expected = new ProcessObject().Find<ListBoxControlObject<IListDataTemplateObject>>();
+            var proc = new ProcessObject().Find<IListBoxControlObject<IListDataTemplateObject>>();
+            Assert.AreEqual(expected.GetType(), proc.GetType());
+            Assert.AreEqual(typeof(ListDataTemplateObject), proc.Value.GetType());
+        }
+
+        [Test]
+        public void WhenTryingToFindControlObjectWithGenericArgument_NoExceptionIsThrown()
+        {
+            Assert.DoesNotThrow(() => new ProcessObject().Find<IListBoxControlObject<IListDataTemplateObject>>());
+        }
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ListBoxControlObject.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ListBoxControlObject.cs
@@ -1,0 +1,14 @@
+﻿namespace CoparooInterfaceTest
+{
+    using Trumpf.Coparoo.Desktop.WPF;
+
+    public interface IListBoxControlObject<T> : IControlObject where T : IControlObject
+    {
+        T Value { get; }
+    }
+
+    public class ListBoxControlObject<T> : ViewControlObject<ListBox>, IListBoxControlObject<T> where T : IControlObject
+    {
+        public T Value => Find<T>();
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ListDataTemplateObject.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/ListDataTemplateObject.cs
@@ -1,0 +1,10 @@
+﻿namespace CoparooInterfaceTest
+{
+    public interface IListDataTemplateObject : IDataTemplateObjectBase
+    {
+    }
+
+    public class ListDataTemplateObject : DataTemplateObjectBase<FrameworkElement>, IListDataTemplateObject
+    {
+    }
+}

--- a/Trumpf.Coparoo.Desktop.Tests/GenericArguments/RootObject.cs
+++ b/Trumpf.Coparoo.Desktop.Tests/GenericArguments/RootObject.cs
@@ -1,0 +1,8 @@
+﻿namespace CoparooInterfaceTest
+{
+    using Trumpf.Coparoo.Desktop;
+
+    public class RootObject : ProcessObject
+    {
+    }
+}

--- a/Trumpf.Coparoo.Desktop/Core/RootObject/Locators/UIObjectInterfaceResolver.cs
+++ b/Trumpf.Coparoo.Desktop/Core/RootObject/Locators/UIObjectInterfaceResolver.cs
@@ -71,8 +71,8 @@ namespace Trumpf.Coparoo.Desktop.Core
                     ? controlTypesCache.Where(e => toResolve.IsAssignableFrom(e)).ToArray()
                     : controlTypesCache
                         .Where(e => e.GetTypeInfo().GenericTypeParameters.Length == toResolve.GenericTypeArguments.Length)
-                        .Select(e => e.MakeGenericType(toResolve.GenericTypeArguments))
-                        .Where(e => toResolve.IsAssignableFrom(e))
+                        .Select(candidateType => TryResolve(candidateType, toResolve.GenericTypeArguments))
+                        .Where(e => e != null && toResolve.IsAssignableFrom(e))
                         .ToArray();
 
                 if (!matches.Any() && !retryOnce)
@@ -98,6 +98,18 @@ namespace Trumpf.Coparoo.Desktop.Core
             }
 
             return result;
+        }
+
+        private static Type TryResolve(Type candidateType, Type[] genericTypeArguments)
+        {
+            try
+            {
+                return candidateType.MakeGenericType(genericTypeArguments);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes Exceptions when trying to Find interface types with generic arguments
`Find<IMyControl<IMyChildControl>>()`

Added corresponding tests. Together with @kaiseral 